### PR TITLE
API Improvements and Bug Fixes

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -264,8 +264,6 @@ def refresh_data_util():
         return (df, dates)
 
     for key, value in source_list.items():
-        if key in ['COVID Tracking Project', 'NY Times']:
-            continue
         if key != 'JHU':
             file_list[key] = prc(value)
         else:


### PR DESCRIPTION
- Fixed missing COVID Tracking Project and NY Times data.
- Added Chinese and Canadian provinces. Note that some provinces are NOT covered in the JHU Global Time Series file; thus, there is no data for them. An example is Xizang, China.

@v3nd3774 @824zzy: Please let me know when this is merged and the server is updated. I need to ensure that the COVID Tracking Project and NY Times data files are working with the API as intended.